### PR TITLE
v0.7.2: Relax the ESLint ruleset

### DIFF
--- a/.github/workflows/push-feature.yml
+++ b/.github/workflows/push-feature.yml
@@ -48,8 +48,6 @@ jobs:
         platform:
           - os: ubuntu-latest
             shell: bash
-          - os: macos-latest
-            shell: bash
           - os: windows-latest
             shell: bash
           - os: windows-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/lints-config",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "My configuration for the ESLint / Prettier / TypeScript",
   "keywords": [

--- a/packages/eslint-config-base/.eslintrc.yml
+++ b/packages/eslint-config-base/.eslintrc.yml
@@ -13,8 +13,8 @@ extends:
   - eslint:recommended
   - plugin:import/recommended
   - plugin:import/typescript
-  - plugin:@typescript-eslint/recommended-type-checked
-  - plugin:@typescript-eslint/stylistic-type-checked
+  - plugin:@typescript-eslint/recommended
+  - plugin:@typescript-eslint/stylistic
   # Because we want to apply the Airbnb rules as much as possible,
   # we have placed them closer to the end.
   - airbnb-typescript/base

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/eslint-config-base",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "My ESLint configuration for general Node.js projects",
   "keywords": [
     "config",

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/eslint-config-react",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "My ESLint configuration for React projects",
   "keywords": [
     "config",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/prettier-config",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "My Prettier configuration for general projects",
   "keywords": [
     "config",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/typescript-config",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "My TypeScript configuration for general projects",
   "keywords": [
     "config",


### PR DESCRIPTION
## Features

- 0995468: relaxed the ESLint ruleset

## Other updates

- eb57bbe: removed the testing for macOS on GitHub Actions
  - Because it costs too much, and since my PC environment is macOS, I figured it was unnecessary to test on GitHub Actions.
